### PR TITLE
Add security configuration and user management

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,10 @@ dependencies {
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	runtimeOnly 'org.postgresql:postgresql'
+        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+        implementation 'org.springframework.boot:spring-boot-starter-web'
+        implementation 'org.springframework.boot:spring-boot-starter-security'
+        runtimeOnly 'org.postgresql:postgresql'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/SpringSecurityKeyVaultExampleApplication.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/SpringSecurityKeyVaultExampleApplication.java
@@ -1,13 +1,30 @@
 package com.fontolan.spring.securitykeyvault.example;
 
+import com.fontolan.spring.securitykeyvault.example.auth.User;
+import com.fontolan.spring.securitykeyvault.example.auth.UserService;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.boot.CommandLineRunner;
 
 @SpringBootApplication
 public class SpringSecurityKeyVaultExampleApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(SpringSecurityKeyVaultExampleApplication.class, args);
-	}
+        public static void main(String[] args) {
+                SpringApplication.run(SpringSecurityKeyVaultExampleApplication.class, args);
+        }
+
+        @Bean
+        CommandLineRunner init(UserService userService) {
+                return args -> {
+                        if (userService.findAll().isEmpty()) {
+                                User user = new User();
+                                user.setUsername("admin");
+                                user.setPassword("admin");
+                                user.setRoles("ROLE_USER,ROLE_ADMIN");
+                                userService.save(user);
+                        }
+                };
+        }
 
 }

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/User.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/User.java
@@ -1,0 +1,22 @@
+package com.fontolan.spring.securitykeyvault.example.auth;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    // Comma separated roles, e.g. "ROLE_USER,ROLE_ADMIN"
+    private String roles;
+}

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/UserRepository.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/UserRepository.java
@@ -1,0 +1,11 @@
+package com.fontolan.spring.securitykeyvault.example.auth;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/UserService.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/UserService.java
@@ -1,0 +1,55 @@
+package com.fontolan.spring.securitykeyvault.example.auth;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class UserService implements UserDetailsService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public User save(User user) {
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
+        return userRepository.save(user);
+    }
+
+    public List<User> findAll() {
+        return userRepository.findAll();
+    }
+
+    public void delete(Long id) {
+        userRepository.deleteById(id);
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        return new org.springframework.security.core.userdetails.User(
+                user.getUsername(),
+                user.getPassword(),
+                getAuthorities(user.getRoles()));
+    }
+
+    private Collection<? extends GrantedAuthority> getAuthorities(String roles) {
+        return Arrays.stream(roles.split(","))
+                .map(String::trim)
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/configs/SecurityConfig.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/configs/SecurityConfig.java
@@ -1,0 +1,40 @@
+package com.fontolan.spring.securitykeyvault.example.configs;
+
+import com.fontolan.spring.securitykeyvault.example.auth.UserService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final UserService userService;
+
+    public SecurityConfig(UserService userService) {
+        this.userService = userService;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/v1/products/**").authenticated()
+                .anyRequest().permitAll())
+            .userDetailsService(userService)
+            .formLogin(Customizer.withDefaults())
+            .httpBasic(Customizer.withDefaults());
+        return http.build();
+    }
+}


### PR DESCRIPTION
## Summary
- add Spring Security dependency
- implement `User` entity, repository, and service
- configure `SecurityConfig` with password-based login
- seed a default admin user for testing

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684c4123f2a8832fbb536d9669e12ce9