### PR TITLE
Implement JWT login with token revocation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,12 @@ dependencies {
         implementation 'org.springframework.boot:spring-boot-starter-web'
         implementation 'org.springframework.boot:spring-boot-starter-security'
         runtimeOnly 'org.postgresql:postgresql'
+        implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+        runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+        runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+        testImplementation 'org.springframework.boot:spring-boot-starter-test'
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,52 @@
+package com.fontolan.spring.securitykeyvault.example.auth.jwt;
+
+import com.fontolan.spring.securitykeyvault.example.auth.tokens.TokenService;
+import com.fontolan.spring.securitykeyvault.example.auth.UserService;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+    private final TokenService tokenService;
+    private final UserService userService;
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil, TokenService tokenService, UserService userService) {
+        this.jwtUtil = jwtUtil;
+        this.tokenService = tokenService;
+        this.userService = userService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+            try {
+                String username = jwtUtil.getUsername(token);
+                if (!jwtUtil.isExpired(token) && tokenService.isTokenValid(token) &&
+                        SecurityContextHolder.getContext().getAuthentication() == null) {
+                    UserDetails userDetails = userService.loadUserByUsername(username);
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            } catch (Exception ignored) {
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/jwt/JwtUtil.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/jwt/JwtUtil.java
@@ -1,0 +1,48 @@
+package com.fontolan.spring.securitykeyvault.example.auth.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+    private final Key key;
+    private static final long EXPIRATION_MS = 3600_000; // 1 hour
+
+    public JwtUtil() {
+        // In real apps use a stronger key and load from config
+        byte[] secret = Decoders.BASE64.decode("YXdzZW9tZWhzZWNyZXQxMjM0NQ==");
+        this.key = Keys.hmacShaKeyFor(secret);
+    }
+
+    public String generateToken(String username) {
+        Date now = new Date();
+        Date exp = new Date(now.getTime() + EXPIRATION_MS);
+        return Jwts.builder()
+                .setSubject(username)
+                .setIssuedAt(now)
+                .setExpiration(exp)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String getUsername(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    public boolean isExpired(String token) {
+        Date expiration = Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration();
+        return expiration.before(new Date());
+    }
+}

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/tokens/Token.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/tokens/Token.java
@@ -1,0 +1,21 @@
+package com.fontolan.spring.securitykeyvault.example.auth.tokens;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "tokens")
+public class Token {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 512)
+    private String token;
+
+    @Column(nullable = false)
+    private String username;
+
+    private boolean revoked;
+}

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/tokens/TokenRepository.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/tokens/TokenRepository.java
@@ -1,0 +1,11 @@
+package com.fontolan.spring.securitykeyvault.example.auth.tokens;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface TokenRepository extends JpaRepository<Token, Long> {
+    Optional<Token> findByToken(String token);
+}

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/tokens/TokenService.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/tokens/TokenService.java
@@ -1,0 +1,36 @@
+package com.fontolan.spring.securitykeyvault.example.auth.tokens;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class TokenService {
+    private final TokenRepository tokenRepository;
+
+    public TokenService(TokenRepository tokenRepository) {
+        this.tokenRepository = tokenRepository;
+    }
+
+    @Transactional
+    public void saveToken(String token, String username) {
+        Token t = new Token();
+        t.setToken(token);
+        t.setUsername(username);
+        t.setRevoked(false);
+        tokenRepository.save(t);
+    }
+
+    public boolean isTokenValid(String token) {
+        return tokenRepository.findByToken(token)
+                .filter(t -> !t.isRevoked())
+                .isPresent();
+    }
+
+    @Transactional
+    public void revokeToken(String token) {
+        tokenRepository.findByToken(token).ifPresent(t -> {
+            t.setRevoked(true);
+            tokenRepository.save(t);
+        });
+    }
+}

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/configs/SecurityConfig.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/configs/SecurityConfig.java
@@ -1,11 +1,16 @@
 package com.fontolan.spring.securitykeyvault.example.configs;
 
 import com.fontolan.spring.securitykeyvault.example.auth.UserService;
+import com.fontolan.spring.securitykeyvault.example.auth.jwt.JwtAuthenticationFilter;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -15,9 +20,11 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
 
     private final UserService userService;
+    private final JwtAuthenticationFilter jwtFilter;
 
-    public SecurityConfig(UserService userService) {
+    public SecurityConfig(UserService userService, JwtAuthenticationFilter jwtFilter) {
         this.userService = userService;
+        this.jwtFilter = jwtFilter;
     }
 
     @Bean
@@ -26,15 +33,22 @@ public class SecurityConfig {
     }
 
     @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
             .csrf(csrf -> csrf.disable())
+            .sessionManagement(management -> management.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/v1/products/**").authenticated()
                 .anyRequest().permitAll())
             .userDetailsService(userService)
-            .formLogin(Customizer.withDefaults())
-            .httpBasic(Customizer.withDefaults());
+            .addFilterBefore(jwtFilter, org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable);
         return http.build();
     }
 }

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/controllers/AuthController.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/controllers/AuthController.java
@@ -1,0 +1,64 @@
+package com.fontolan.spring.securitykeyvault.example.controllers;
+
+import com.fontolan.spring.securitykeyvault.example.auth.jwt.JwtUtil;
+import com.fontolan.spring.securitykeyvault.example.auth.tokens.TokenService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+    private final AuthenticationManager authenticationManager;
+    private final JwtUtil jwtUtil;
+    private final TokenService tokenService;
+
+    public AuthController(AuthenticationManager authenticationManager, JwtUtil jwtUtil,
+                          TokenService tokenService) {
+        this.authenticationManager = authenticationManager;
+        this.jwtUtil = jwtUtil;
+        this.tokenService = tokenService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody Map<String, String> body) {
+        Authentication auth = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(body.get("username"), body.get("password")));
+        String username = auth.getName();
+        String token = jwtUtil.generateToken(username);
+        tokenService.saveToken(token, username);
+        return ResponseEntity.ok(Map.of("token", token));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refresh(@RequestHeader("Authorization") String header) {
+        if (header != null && header.startsWith("Bearer ")) {
+            String oldToken = header.substring(7);
+            if (!jwtUtil.isExpired(oldToken) && tokenService.isTokenValid(oldToken)) {
+                String username = jwtUtil.getUsername(oldToken);
+                tokenService.revokeToken(oldToken);
+                String newToken = jwtUtil.generateToken(username);
+                tokenService.saveToken(newToken, username);
+                return ResponseEntity.ok(Map.of("token", newToken));
+            }
+        }
+        return ResponseEntity.status(401).build();
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(@RequestHeader("Authorization") String header) {
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+            tokenService.revokeToken(token);
+        }
+        return ResponseEntity.ok().build();
+    }
+}


### PR DESCRIPTION
## Summary
- add `jjwt` dependency
- store tokens in a new `Token` entity with repository/service
- create `JwtUtil` and filter for Authorization header
- expose login/refresh/logout endpoints
- configure Spring Security to use JWT filter

## Testing
- `gradlew test` *(fails: Unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_684c436523a0832f8b87cd6ef3d22ebc