### PR TITLE
Implement role-based checks and device validation

### DIFF
--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/SpringSecurityKeyVaultExampleApplication.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/SpringSecurityKeyVaultExampleApplication.java
@@ -2,6 +2,7 @@ package com.fontolan.spring.securitykeyvault.example;
 
 import com.fontolan.spring.securitykeyvault.example.auth.User;
 import com.fontolan.spring.securitykeyvault.example.auth.UserService;
+import com.fontolan.spring.securitykeyvault.example.auth.Role;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
@@ -21,7 +22,7 @@ public class SpringSecurityKeyVaultExampleApplication {
                                 User user = new User();
                                 user.setUsername("admin");
                                 user.setPassword("admin");
-                                user.setRoles("ROLE_USER,ROLE_ADMIN");
+                                user.setRoles(java.util.Set.of(Role.ROLE_USER, Role.ROLE_ADMIN));
                                 userService.save(user);
                         }
                 };

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/Role.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/Role.java
@@ -1,0 +1,6 @@
+package com.fontolan.spring.securitykeyvault.example.auth;
+
+public enum Role {
+    ROLE_USER,
+    ROLE_ADMIN
+}

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/User.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/User.java
@@ -3,6 +3,9 @@ package com.fontolan.spring.securitykeyvault.example.auth;
 import jakarta.persistence.*;
 import lombok.Data;
 import java.time.LocalDateTime;
+import java.util.Set;
+
+import com.fontolan.spring.securitykeyvault.example.auth.Role;
 
 @Data
 @Entity
@@ -18,8 +21,10 @@ public class User {
     @Column(nullable = false)
     private String password;
 
-    // Comma separated roles, e.g. "ROLE_USER,ROLE_ADMIN"
-    private String roles;
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "user_roles", joinColumns = @JoinColumn(name = "user_id"))
+    @Enumerated(EnumType.STRING)
+    private Set<Role> roles;
 
     private String resetToken;
 

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/UserService.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/UserService.java
@@ -16,7 +16,10 @@ import java.util.UUID;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
+
+import com.fontolan.spring.securitykeyvault.example.auth.Role;
 
 @Service
 public class UserService implements UserDetailsService {
@@ -93,10 +96,9 @@ public class UserService implements UserDetailsService {
                 getAuthorities(user.getRoles()));
     }
 
-    private Collection<? extends GrantedAuthority> getAuthorities(String roles) {
-        return Arrays.stream(roles.split(","))
-                .map(String::trim)
-                .map(SimpleGrantedAuthority::new)
+    private Collection<? extends GrantedAuthority> getAuthorities(java.util.Set<Role> roles) {
+        return roles.stream()
+                .map(role -> new SimpleGrantedAuthority(role.name()))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/devices/UserDeviceService.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/devices/UserDeviceService.java
@@ -37,4 +37,12 @@ public class UserDeviceService {
     public java.util.List<UserDevice> listDevices(String username) {
         return repository.findByUsername(username);
     }
+
+    public boolean isTrustedDevice(String username, HttpServletRequest request) {
+        String agent = request.getHeader("User-Agent");
+        String ip = request.getRemoteAddr();
+        return repository.findByUsernameAndUserAgentAndIp(username, agent, ip)
+                .map(UserDevice::isTrusted)
+                .orElse(false);
+    }
 }

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/configs/SecurityConfig.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/configs/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -17,6 +18,7 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
 
     private final UserService userService;
@@ -43,7 +45,7 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable())
             .sessionManagement(management -> management.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/api/v1/products/**").authenticated()
+                .requestMatchers("/api/v1/products/**").hasAnyRole("USER","ADMIN")
                 .anyRequest().permitAll())
             .userDetailsService(userService)
             .addFilterBefore(jwtFilter, org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/controllers/AuthController.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/controllers/AuthController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -104,11 +105,13 @@ public class AuthController {
     }
 
     @GetMapping("/devices")
+    @PreAuthorize("hasAnyRole('USER','ADMIN')")
     public ResponseEntity<?> listDevices(Authentication authentication) {
         return ResponseEntity.ok(tokenService.activeTokens(authentication.getName()));
     }
 
     @PostMapping("/devices/{id}/revoke")
+    @PreAuthorize("hasAnyRole('USER','ADMIN')")
     public ResponseEntity<?> revokeDevice(@PathVariable Long id) {
         tokenService.revokeTokenById(id);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/controllers/ProductController.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/controllers/ProductController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 @RestController
 @RequestMapping("/api/v1/products")
@@ -20,9 +22,11 @@ public class ProductController {
     }
 
     @GetMapping
+    @PreAuthorize("hasAnyRole('USER','ADMIN') and @userDeviceService.isTrustedDevice(authentication.name, #request)")
     public Page<Product> listarProdutos(
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size) {
+            @RequestParam(defaultValue = "10") int size,
+            HttpServletRequest request) {
         Pageable pageable = PageRequest.of(page, size);
 
         return productService.getAll(pageable);


### PR DESCRIPTION
## Summary
- add `Role` enum
- store roles via `Set<Role>` in `User`
- grant roles in default admin user
- enable method security and restrict product endpoints to users with proper roles
- require device trust via `@PreAuthorize` on `ProductController`
- restrict device management endpoints by role
- provide helper to verify trusted devices

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684d1fbba2bc832fb9610565622be07f