### PR TITLE
Enable OAuth2 login providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ You need to create a `.env` file at the root of the project with the following A
 AWS_ACCESS_KEY_ID=your_access_key_id
 AWS_SECRET_ACCESS_KEY=your_secret_access_key
 AWS_REGION=us-east-1
+GOOGLE_CLIENT_ID=your_google_client_id
+GOOGLE_CLIENT_SECRET=your_google_client_secret
+FACEBOOK_CLIENT_ID=your_facebook_client_id
+FACEBOOK_CLIENT_SECRET=your_facebook_client_secret
+KEYCLOAK_CLIENT_SECRET=your_keycloak_client_secret
 ```
 
 Replace `your_access_key_id` and `your_secret_access_key` with your actual AWS credentials.
@@ -53,6 +58,14 @@ LocalStack is used to emulate AWS services like Secrets Manager. The configurati
 ## Health Check
 
 Health checks are configured for PostgreSQL and LocalStack to ensure the services are fully started before the Spring Boot application begins.
+
+## OAuth2 Login
+
+The application supports OAuth2 login with Google, Facebook and Keycloak. Configure the client secrets in the `.env` file and access the following endpoints to initiate authentication:
+
+- `/oauth2/authorization/google`
+- `/oauth2/authorization/facebook`
+- `/oauth2/authorization/keycloak`
 
 ## Access the Application
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ dependencies {
         implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
         implementation 'org.springframework.boot:spring-boot-starter-web'
         implementation 'org.springframework.boot:spring-boot-starter-security'
+        implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+        implementation 'org.keycloak:keycloak-spring-boot-starter:24.0.4'
         implementation 'org.springframework.boot:spring-boot-starter-mail'
         runtimeOnly 'org.postgresql:postgresql'
         implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,20 @@ services:
     networks:
       - localnetwork
 
+  keycloak:
+    image: quay.io/keycloak/keycloak:24.0.4
+    container_name: keycloak
+    command: start-dev --http-port=8081 --import-realm
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+    ports:
+      - "8081:8081"
+    volumes:
+      - ./scripts/realm-export.json:/opt/keycloak/data/import/realm.json
+    networks:
+      - localnetwork
+
   product-app:
     build:
       context: .
@@ -70,6 +84,8 @@ services:
       localstack:
         condition: service_healthy
       localstack.configurator:
+        condition: service_started
+      keycloak:
         condition: service_started
     networks:
       - localnetwork

--- a/scripts/realm-export.json
+++ b/scripts/realm-export.json
@@ -1,0 +1,12 @@
+{
+  "realm": "myrealm",
+  "enabled": true,
+  "clients": [
+    {
+      "clientId": "myapp",
+      "secret": "${KEYCLOAK_CLIENT_SECRET}",
+      "redirectUris": ["http://localhost:8080/login/oauth2/code/keycloak"],
+      "publicClient": false
+    }
+  ]
+}

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/AuthProvider.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/AuthProvider.java
@@ -1,0 +1,8 @@
+package com.fontolan.spring.securitykeyvault.example.auth;
+
+public enum AuthProvider {
+    LOCAL,
+    GOOGLE,
+    FACEBOOK,
+    KEYCLOAK
+}

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/User.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/User.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.util.Set;
 
 import com.fontolan.spring.securitykeyvault.example.auth.Role;
+import com.fontolan.spring.securitykeyvault.example.auth.AuthProvider;
 
 @Data
 @Entity
@@ -35,4 +36,9 @@ public class User {
 
     // Flag indicating if 2FA is enabled for this user
     private boolean twoFactorEnabled;
+
+    @Enumerated(EnumType.STRING)
+    private AuthProvider provider = AuthProvider.LOCAL;
+
+    private String providerId;
 }

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/UserRepository.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/UserRepository.java
@@ -2,6 +2,7 @@ package com.fontolan.spring.securitykeyvault.example.auth;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import com.fontolan.spring.securitykeyvault.example.auth.AuthProvider;
 
 import java.util.Optional;
 
@@ -9,4 +10,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
     Optional<User> findByResetToken(String resetToken);
+    Optional<User> findByProviderAndProviderId(AuthProvider provider, String providerId);
 }

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,55 @@
+package com.fontolan.spring.securitykeyvault.example.auth.oauth2;
+
+import com.fontolan.spring.securitykeyvault.example.auth.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final DefaultOAuth2UserService delegate = new DefaultOAuth2UserService();
+
+    public CustomOAuth2UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oauth2User = delegate.loadUser(userRequest);
+        AuthProvider provider = AuthProvider.valueOf(userRequest.getClientRegistration().getRegistrationId().toUpperCase());
+        String providerId = oauth2User.getName();
+
+        User user = userRepository.findByProviderAndProviderId(provider, providerId)
+                .orElseGet(() -> {
+                    User u = new User();
+                    u.setUsername(oauth2User.getAttribute("email"));
+                    u.setPassword(passwordEncoder.encode(UUID.randomUUID().toString()));
+                    u.setRoles(Set.of(Role.ROLE_USER));
+                    u.setProvider(provider);
+                    u.setProviderId(providerId);
+                    return userRepository.save(u);
+                });
+
+        String usernameAttr = userRequest.getClientRegistration()
+                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+        return new DefaultOAuth2User(
+                user.getRoles().stream().map(r -> new SimpleGrantedAuthority(r.name())).toList(),
+                oauth2User.getAttributes(),
+                usernameAttr);
+    }
+}

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/configs/SecurityConfig.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/configs/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.fontolan.spring.securitykeyvault.example.configs;
 
 import com.fontolan.spring.securitykeyvault.example.auth.UserService;
 import com.fontolan.spring.securitykeyvault.example.auth.jwt.JwtAuthenticationFilter;
+import com.fontolan.spring.securitykeyvault.example.auth.oauth2.CustomOAuth2UserService;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -23,10 +24,13 @@ public class SecurityConfig {
 
     private final UserService userService;
     private final JwtAuthenticationFilter jwtFilter;
+    private final CustomOAuth2UserService oAuth2UserService;
 
-    public SecurityConfig(UserService userService, JwtAuthenticationFilter jwtFilter) {
+    public SecurityConfig(UserService userService, JwtAuthenticationFilter jwtFilter,
+                          CustomOAuth2UserService oAuth2UserService) {
         this.userService = userService;
         this.jwtFilter = jwtFilter;
+        this.oAuth2UserService = oAuth2UserService;
     }
 
     @Bean
@@ -50,7 +54,10 @@ public class SecurityConfig {
             .userDetailsService(userService)
             .addFilterBefore(jwtFilter, org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class)
             .formLogin(AbstractHttpConfigurer::disable)
-            .httpBasic(AbstractHttpConfigurer::disable);
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .oauth2Login(oauth -> oauth
+                .userInfoEndpoint(info -> info.userService(oAuth2UserService))
+            );
         return http.build();
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,6 +9,35 @@ spring:
   jackson:
     serialization:
       indent-output: true
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            scope:
+              - openid
+              - profile
+              - email
+          facebook:
+            client-id: ${FACEBOOK_CLIENT_ID}
+            client-secret: ${FACEBOOK_CLIENT_SECRET}
+            scope:
+              - public_profile
+              - email
+          keycloak:
+            client-id: myapp
+            client-secret: ${KEYCLOAK_CLIENT_SECRET}
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            scope:
+              - openid
+              - profile
+              - email
+        provider:
+          keycloak:
+            issuer-uri: http://localhost:8081/realms/myrealm
 aws:
   region: us-east-1
   secrets:


### PR DESCRIPTION
## Summary
- add OAuth2 client and Keycloak dependencies
- configure OAuth2 client registrations for Google, Facebook and Keycloak
- run Keycloak in docker-compose
- map external identities to local users with a custom OAuth2 user service
- document OAuth2 login and new environment variables

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684d22012cc8832f880ca5530181763f