### PR TITLE
Document security env vars and auth workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ GOOGLE_CLIENT_SECRET=your_google_client_secret
 FACEBOOK_CLIENT_ID=your_facebook_client_id
 FACEBOOK_CLIENT_SECRET=your_facebook_client_secret
 KEYCLOAK_CLIENT_SECRET=your_keycloak_client_secret
+JWT_SECRET=base64_encoded_secret
 ```
-
 Replace `your_access_key_id` and `your_secret_access_key` with your actual AWS credentials.
+`JWT_SECRET` must be a Base64 encoded string used to sign JWT tokens.
 
 ## How to Run the Project
 
@@ -76,6 +77,51 @@ http://localhost:8080
 ```
 
 Make sure all services are running properly by checking the Docker logs.
+
+### Running with Authentication
+
+The application starts with a default `admin` user (password `admin`).
+Ensure the `JWT_SECRET` and OAuth2 variables are configured in the `.env` file
+before starting:
+
+```bash
+docker-compose up
+```
+
+Once running you can register new users and authenticate using the following
+REST endpoints.
+
+### Authentication Endpoints
+
+- **Register** a new user
+
+  ```bash
+  curl -X POST http://localhost:8080/api/auth/register \
+    -H "Content-Type: application/json" \
+    -d '{"username":"user1","password":"mypassword"}'
+  ```
+
+- **Login** and receive a JWT
+
+  ```bash
+  curl -X POST http://localhost:8080/api/auth/login \
+    -H "Content-Type: application/json" \
+    -d '{"username":"user1","password":"mypassword"}'
+  ```
+
+- **Refresh** an existing token
+
+  ```bash
+  curl -X POST http://localhost:8080/api/auth/refresh \
+    -H "Authorization: Bearer <old_token>"
+  ```
+
+- **Logout** (revokes the token)
+
+  ```bash
+  curl -X POST http://localhost:8080/api/auth/logout \
+    -H "Authorization: Bearer <token>"
+  ```
 
 ## Two-factor Authentication
 

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/jwt/JwtUtil.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/auth/jwt/JwtUtil.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
@@ -14,9 +15,8 @@ public class JwtUtil {
     private final Key key;
     private static final long EXPIRATION_MS = 3600_000; // 1 hour
 
-    public JwtUtil() {
-        // In real apps use a stronger key and load from config
-        byte[] secret = Decoders.BASE64.decode("YXdzZW9tZWhzZWNyZXQxMjM0NQ==");
+    public JwtUtil(@Value("${JWT_SECRET:YXdzZW9tZWhzZWNyZXQxMjM0NQ==}") String secretBase64) {
+        byte[] secret = Decoders.BASE64.decode(secretBase64);
         this.key = Keys.hmacShaKeyFor(secret);
     }
 

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/controllers/AuthController.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/controllers/AuthController.java
@@ -33,6 +33,16 @@ public class AuthController {
         this.deviceService = deviceService;
     }
 
+    @PostMapping("/register")
+    public ResponseEntity<?> register(@RequestBody Map<String, String> body) {
+        var user = new com.fontolan.spring.securitykeyvault.example.auth.User();
+        user.setUsername(body.get("username"));
+        user.setPassword(body.get("password"));
+        user.setRoles(java.util.Set.of(com.fontolan.spring.securitykeyvault.example.auth.Role.ROLE_USER));
+        userService.save(user);
+        return ResponseEntity.ok().build();
+    }
+
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody Map<String, String> body, HttpServletRequest request) {
         Authentication auth = authenticationManager.authenticate(


### PR DESCRIPTION
## Summary
- load JWT secret from `JWT_SECRET` environment variable
- add user registration endpoint
- update README with JWT secret configuration and example auth requests

## Testing
- `./gradlew test --no-daemon` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684d269a29e8832fb0324f89abd5c53c