### PR TITLE
Switch to Google API client for two-factor auth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
         implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
         runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
         runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
-        implementation 'com.warrenstrange:googleauth:1.6.0'
+        implementation 'com.google.api-client:google-api-client:2.2.0'
 
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/application/service/TwoFactorAuthService.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/application/service/TwoFactorAuthService.java
@@ -1,0 +1,51 @@
+package com.fontolan.spring.securitykeyvault.example.application.service;
+
+import com.google.api.client.util.Base64;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.ByteBuffer;
+import java.security.SecureRandom;
+
+public class TwoFactorAuthService {
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public String generateSecret() {
+        byte[] bytes = new byte[20];
+        secureRandom.nextBytes(bytes);
+        return Base64.encodeBase64URLSafeString(bytes);
+    }
+
+    public boolean verifyCode(String secret, int code) {
+        long timeIndex = System.currentTimeMillis() / 1000 / 30;
+        byte[] key = Base64.decodeBase64(secret);
+        try {
+            for (int i = -1; i <= 1; i++) {
+                if (generateCode(key, timeIndex + i) == code) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private int generateCode(byte[] key, long timestep) throws Exception {
+        ByteBuffer buffer = ByteBuffer.allocate(8);
+        buffer.putLong(timestep);
+        byte[] data = buffer.array();
+
+        Mac mac = Mac.getInstance("HmacSHA1");
+        SecretKeySpec signKey = new SecretKeySpec(key, "HmacSHA1");
+        mac.init(signKey);
+        byte[] hash = mac.doFinal(data);
+
+        int offset = hash[hash.length - 1] & 0xF;
+        int truncatedHash = ((hash[offset] & 0x7f) << 24)
+                | ((hash[offset + 1] & 0xff) << 16)
+                | ((hash[offset + 2] & 0xff) << 8)
+                | (hash[offset + 3] & 0xff);
+        return truncatedHash % 1000000;
+    }
+}

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/application/service/UserService.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/application/service/UserService.java
@@ -11,8 +11,7 @@ import com.fontolan.spring.securitykeyvault.example.application.service.Notifica
 import com.fontolan.spring.securitykeyvault.example.domain.repository.UserRepository;
 import com.fontolan.spring.securitykeyvault.example.domain.model.User;
 import com.fontolan.spring.securitykeyvault.example.domain.model.Role;
-import com.warrenstrange.googleauth.GoogleAuthenticator;
-import com.warrenstrange.googleauth.GoogleAuthenticatorKey;
+import com.fontolan.spring.securitykeyvault.example.application.service.TwoFactorAuthService;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -28,14 +27,14 @@ public class UserService implements UserDetailsService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final NotificationService notificationService;
-    private final GoogleAuthenticator googleAuthenticator;
+    private final TwoFactorAuthService twoFactorAuthService;
 
     public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder,
-                       NotificationService notificationService, GoogleAuthenticator googleAuthenticator) {
+                       NotificationService notificationService, TwoFactorAuthService twoFactorAuthService) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.notificationService = notificationService;
-        this.googleAuthenticator = googleAuthenticator;
+        this.twoFactorAuthService = twoFactorAuthService;
     }
 
     public User save(User user) {
@@ -110,12 +109,11 @@ public class UserService implements UserDetailsService {
     }
 
     public String generateTwoFactorSecret() {
-        GoogleAuthenticatorKey key = googleAuthenticator.createCredentials();
-        return key.getKey();
+        return twoFactorAuthService.generateSecret();
     }
 
     public boolean verifyTwoFactorCode(String secret, int code) {
-        return googleAuthenticator.authorize(secret, code);
+        return twoFactorAuthService.verifyCode(secret, code);
     }
 }
 

--- a/src/main/java/com/fontolan/spring/securitykeyvault/example/infrastructure/config/TwoFactorConfig.java
+++ b/src/main/java/com/fontolan/spring/securitykeyvault/example/infrastructure/config/TwoFactorConfig.java
@@ -1,14 +1,14 @@
 package com.fontolan.spring.securitykeyvault.example.infrastructure.config;
 
-import com.warrenstrange.googleauth.GoogleAuthenticator;
+import com.fontolan.spring.securitykeyvault.example.application.service.TwoFactorAuthService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class TwoFactorConfig {
     @Bean
-    public GoogleAuthenticator googleAuthenticator() {
-        return new GoogleAuthenticator();
+    public TwoFactorAuthService twoFactorAuthService() {
+        return new TwoFactorAuthService();
     }
 }
 


### PR DESCRIPTION
## Summary
- replace deprecated `googleauth` library with Google API client dependency
- create `TwoFactorAuthService` for generating and verifying TOTP codes
- wire new service in `UserService` and configuration

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684d3821469c832fb25b98f89c3beac2