### PR TITLE
Add comprehensive test suite

### DIFF
--- a/src/test/java/com/fontolan/spring/securitykeyvault/example/SpringSecurityKeyVaultExampleApplicationTests.java
+++ b/src/test/java/com/fontolan/spring/securitykeyvault/example/SpringSecurityKeyVaultExampleApplicationTests.java
@@ -1,13 +1,20 @@
 package com.fontolan.spring.securitykeyvault.example;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.boot.test.context.SpringBootTest;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 class SpringSecurityKeyVaultExampleApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Autowired
+    ApplicationContext context;
+
+    @Test
+    void contextLoads() {
+        assertThat(context).isNotNull();
+    }
 
 }

--- a/src/test/java/com/fontolan/spring/securitykeyvault/example/adapters/security/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/fontolan/spring/securitykeyvault/example/adapters/security/jwt/JwtAuthenticationFilterTest.java
@@ -1,0 +1,68 @@
+package com.fontolan.spring.securitykeyvault.example.adapters.security.jwt;
+
+import com.fontolan.spring.securitykeyvault.example.application.service.TokenService;
+import com.fontolan.spring.securitykeyvault.example.application.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class JwtAuthenticationFilterTest {
+    private JwtUtil util;
+    private TokenService tokenService;
+    private UserService userService;
+    private JwtAuthenticationFilter filter;
+
+    @BeforeEach
+    void setup() {
+        util = new JwtUtil("eJTkszxyBZtYaehPvTL/bP13pgQR1GCYoppvyRrLXgI=");
+        tokenService = mock(TokenService.class);
+        userService = mock(UserService.class);
+        filter = new JwtAuthenticationFilter(util, tokenService, userService);
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void validTokenSetsAuthentication() throws ServletException, IOException {
+        String token = util.generateToken("alice");
+        when(tokenService.isTokenValid(token)).thenReturn(true);
+        when(userService.loadUserByUsername("alice"))
+                .thenReturn(new User("alice", "p", java.util.List.of()));
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer " + token);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilterInternal(request, response, chain);
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(auth).isNotNull();
+        assertThat(auth.getName()).isEqualTo("alice");
+    }
+
+    @Test
+    void invalidTokenDoesNotAuthenticate() throws Exception {
+        String token = util.generateToken("bob");
+        when(tokenService.isTokenValid(token)).thenReturn(false);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer " + token);
+        FilterChain chain = mock(FilterChain.class);
+        filter.doFilterInternal(request, new MockHttpServletResponse(), chain);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+}

--- a/src/test/java/com/fontolan/spring/securitykeyvault/example/adapters/security/jwt/JwtUtilTest.java
+++ b/src/test/java/com/fontolan/spring/securitykeyvault/example/adapters/security/jwt/JwtUtilTest.java
@@ -1,0 +1,41 @@
+package com.fontolan.spring.securitykeyvault.example.adapters.security.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.Test;
+
+import java.security.Key;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JwtUtilTest {
+    private static final String SECRET = "eJTkszxyBZtYaehPvTL/bP13pgQR1GCYoppvyRrLXgI=";
+
+    @Test
+    void generateAndParseToken() {
+        JwtUtil util = new JwtUtil(SECRET);
+        String token = util.generateToken("alice");
+        assertThat(util.getUsername(token)).isEqualTo("alice");
+        assertThat(util.isExpired(token)).isFalse();
+    }
+
+    @Test
+    void expiredTokenIsDetected() {
+        byte[] bytes = Decoders.BASE64.decode(SECRET);
+        Key key = Keys.hmacShaKeyFor(bytes);
+        Date now = new Date();
+        String token = Jwts.builder()
+                .setSubject("bob")
+                .setIssuedAt(new Date(now.getTime() - 7200_000))
+                .setExpiration(new Date(now.getTime() - 3600_000))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        JwtUtil util = new JwtUtil(SECRET);
+        assertThat(util.getUsername(token)).isEqualTo("bob");
+        assertThat(util.isExpired(token)).isTrue();
+    }
+}

--- a/src/test/java/com/fontolan/spring/securitykeyvault/example/adapters/web/AuthControllerTest.java
+++ b/src/test/java/com/fontolan/spring/securitykeyvault/example/adapters/web/AuthControllerTest.java
@@ -1,0 +1,80 @@
+package com.fontolan.spring.securitykeyvault.example.adapters.web;
+
+import com.fontolan.spring.securitykeyvault.example.adapters.security.jwt.JwtUtil;
+import com.fontolan.spring.securitykeyvault.example.application.service.TokenService;
+import com.fontolan.spring.securitykeyvault.example.application.service.UserDeviceService;
+import com.fontolan.spring.securitykeyvault.example.application.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@WebMvcTest(AuthController.class)
+class AuthControllerTest {
+    @Autowired
+    MockMvc mvc;
+    @MockBean
+    AuthenticationManager authenticationManager;
+    @MockBean
+    JwtUtil jwtUtil;
+    @MockBean
+    TokenService tokenService;
+    @MockBean
+    UserService userService;
+    @MockBean
+    UserDeviceService deviceService;
+
+    @Test
+    void registerCallsService() throws Exception {
+        mvc.perform(MockMvcRequestBuilders.post("/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"u\",\"password\":\"p\"}"))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+        verify(userService).save(any());
+    }
+
+    @Test
+    void loginSuccess() throws Exception {
+        Authentication auth = new UsernamePasswordAuthenticationToken("u","p");
+        when(authenticationManager.authenticate(any())).thenReturn(auth);
+        when(deviceService.registerOrUpdate(eq("u"), any())).thenReturn(new com.fontolan.spring.securitykeyvault.example.domain.model.UserDevice());
+        com.fontolan.spring.securitykeyvault.example.domain.model.User user = new com.fontolan.spring.securitykeyvault.example.domain.model.User();
+        user.setTwoFactorEnabled(false);
+        when(userService.getByUsername("u")).thenReturn(user);
+        when(jwtUtil.generateToken("u")).thenReturn("tok");
+
+        mvc.perform(MockMvcRequestBuilders.post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"u\",\"password\":\"p\"}"))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+        verify(tokenService).saveToken(eq("tok"), eq("u"), any());
+    }
+
+    @Test
+    void loginTwoFactorFailure() throws Exception {
+        Authentication auth = new UsernamePasswordAuthenticationToken("u","p");
+        when(authenticationManager.authenticate(any())).thenReturn(auth);
+        com.fontolan.spring.securitykeyvault.example.domain.model.User user = new com.fontolan.spring.securitykeyvault.example.domain.model.User();
+        user.setTwoFactorEnabled(true);
+        user.setTwoFactorSecret("sec");
+        when(userService.getByUsername("u")).thenReturn(user);
+        when(userService.verifyTwoFactorCode("sec", 111111)).thenReturn(false);
+
+        mvc.perform(MockMvcRequestBuilders.post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"u\",\"password\":\"p\",\"code\":\"111111\"}"))
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/fontolan/spring/securitykeyvault/example/adapters/web/ProductControllerTest.java
+++ b/src/test/java/com/fontolan/spring/securitykeyvault/example/adapters/web/ProductControllerTest.java
@@ -1,0 +1,52 @@
+package com.fontolan.spring.securitykeyvault.example.adapters.web;
+
+import com.fontolan.spring.securitykeyvault.example.application.service.ProductService;
+import com.fontolan.spring.securitykeyvault.example.application.service.UserDeviceService;
+import com.fontolan.spring.securitykeyvault.example.domain.model.Product;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(ProductController.class)
+class ProductControllerTest {
+    @Autowired
+    MockMvc mvc;
+    @MockBean
+    ProductService productService;
+    @MockBean
+    UserDeviceService userDeviceService;
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void getAllAuthorizedWhenTrusted() throws Exception {
+        Page<Product> page = new PageImpl<>(List.of(new Product()));
+        when(userDeviceService.isTrustedDevice(any(), any())).thenReturn(true);
+        when(productService.getAll(any(PageRequest.class))).thenReturn(page);
+
+        mvc.perform(MockMvcRequestBuilders.get("/api/v1/products"))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void getAllDeniedWhenNotTrusted() throws Exception {
+        when(userDeviceService.isTrustedDevice(any(), any())).thenReturn(false);
+
+        mvc.perform(MockMvcRequestBuilders.get("/api/v1/products"))
+                .andExpect(MockMvcResultMatchers.status().isForbidden());
+    }
+}

--- a/src/test/java/com/fontolan/spring/securitykeyvault/example/application/service/NotificationServiceTest.java
+++ b/src/test/java/com/fontolan/spring/securitykeyvault/example/application/service/NotificationServiceTest.java
@@ -1,0 +1,41 @@
+package com.fontolan.spring.securitykeyvault.example.application.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class NotificationServiceTest {
+    private JavaMailSender sender;
+    private NotificationService service;
+
+    @BeforeEach
+    void setup() {
+        sender = mock(JavaMailSender.class);
+        service = new NotificationService(sender);
+    }
+
+    @Test
+    void sendTokenMail() {
+        service.sendToken("to", "123");
+        ArgumentCaptor<SimpleMailMessage> captor = ArgumentCaptor.forClass(SimpleMailMessage.class);
+        verify(sender).send(captor.capture());
+        SimpleMailMessage msg = captor.getValue();
+        assertThat(msg.getSubject()).isEqualTo("Your security token");
+        assertThat(msg.getText()).contains("123");
+    }
+
+    @Test
+    void sendSuspiciousLoginMail() {
+        service.sendSuspiciousLogin("to", "info");
+        ArgumentCaptor<SimpleMailMessage> captor = ArgumentCaptor.forClass(SimpleMailMessage.class);
+        verify(sender).send(captor.capture());
+        SimpleMailMessage msg = captor.getValue();
+        assertThat(msg.getSubject()).isEqualTo("New device login detected");
+        assertThat(msg.getText()).contains("info");
+    }
+}

--- a/src/test/java/com/fontolan/spring/securitykeyvault/example/application/service/TokenServiceTest.java
+++ b/src/test/java/com/fontolan/spring/securitykeyvault/example/application/service/TokenServiceTest.java
@@ -1,0 +1,86 @@
+package com.fontolan.spring.securitykeyvault.example.application.service;
+
+import com.fontolan.spring.securitykeyvault.example.domain.model.Token;
+import com.fontolan.spring.securitykeyvault.example.domain.model.UserDevice;
+import com.fontolan.spring.securitykeyvault.example.domain.repository.TokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class TokenServiceTest {
+    private TokenRepository repository;
+    private TokenService service;
+
+    @BeforeEach
+    void setup() {
+        repository = mock(TokenRepository.class);
+        service = new TokenService(repository);
+    }
+
+    @Test
+    void saveTokenWithoutDevice() {
+        service.saveToken("tok", "user");
+        ArgumentCaptor<Token> captor = ArgumentCaptor.forClass(Token.class);
+        verify(repository).save(captor.capture());
+        Token saved = captor.getValue();
+        assertThat(saved.getToken()).isEqualTo("tok");
+        assertThat(saved.getUsername()).isEqualTo("user");
+        assertThat(saved.isRevoked()).isFalse();
+        assertThat(saved.getDevice()).isNull();
+    }
+
+    @Test
+    void saveTokenWithDevice() {
+        UserDevice device = new UserDevice();
+        service.saveToken("tok", "user", device);
+        ArgumentCaptor<Token> captor = ArgumentCaptor.forClass(Token.class);
+        verify(repository).save(captor.capture());
+        Token saved = captor.getValue();
+        assertThat(saved.getDevice()).isSameAs(device);
+    }
+
+    @Test
+    void tokenValidation() {
+        Token t = new Token();
+        t.setToken("tok");
+        t.setRevoked(false);
+        when(repository.findByToken("tok")).thenReturn(Optional.of(t));
+        assertThat(service.isTokenValid("tok")).isTrue();
+
+        t.setRevoked(true);
+        assertThat(service.isTokenValid("tok")).isFalse();
+        when(repository.findByToken("missing")).thenReturn(Optional.empty());
+        assertThat(service.isTokenValid("missing")).isFalse();
+    }
+
+    @Test
+    void activeTokensDelegates() {
+        List<Token> tokens = List.of(new Token());
+        when(repository.findByUsernameAndRevokedFalse("u")).thenReturn(tokens);
+        assertThat(service.activeTokens("u")).isEqualTo(tokens);
+    }
+
+    @Test
+    void revokeToken() {
+        Token token = new Token();
+        when(repository.findByToken("t")).thenReturn(Optional.of(token));
+        service.revokeToken("t");
+        assertThat(token.isRevoked()).isTrue();
+        verify(repository).save(token);
+    }
+
+    @Test
+    void revokeTokenById() {
+        Token token = new Token();
+        when(repository.findById(1L)).thenReturn(Optional.of(token));
+        service.revokeTokenById(1L);
+        assertThat(token.isRevoked()).isTrue();
+        verify(repository).save(token);
+    }
+}

--- a/src/test/java/com/fontolan/spring/securitykeyvault/example/application/service/TwoFactorAuthServiceTest.java
+++ b/src/test/java/com/fontolan/spring/securitykeyvault/example/application/service/TwoFactorAuthServiceTest.java
@@ -1,0 +1,34 @@
+package com.fontolan.spring.securitykeyvault.example.application.service;
+
+import com.google.api.client.util.Base64;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TwoFactorAuthServiceTest {
+
+    @Test
+    void secretIsBase64() {
+        TwoFactorAuthService service = new TwoFactorAuthService();
+        String secret = service.generateSecret();
+        assertThat(Base64.decodeBase64(secret)).isNotEmpty();
+    }
+
+    @Test
+    void verifyCodeUsesGeneratedCode() throws Exception {
+        TwoFactorAuthService service = new TwoFactorAuthService();
+        String secret = service.generateSecret();
+        byte[] key = Base64.decodeBase64(secret);
+
+        Method m = TwoFactorAuthService.class.getDeclaredMethod("generateCode", byte[].class, long.class);
+        m.setAccessible(true);
+        long timeIndex = System.currentTimeMillis() / 1000 / 30;
+        int code = (int) m.invoke(service, key, timeIndex);
+
+        assertThat(service.verifyCode(secret, code)).isTrue();
+        assertThat(service.verifyCode(secret, 999999)).isFalse();
+    }
+}

--- a/src/test/java/com/fontolan/spring/securitykeyvault/example/application/service/UserDeviceServiceTest.java
+++ b/src/test/java/com/fontolan/spring/securitykeyvault/example/application/service/UserDeviceServiceTest.java
@@ -1,0 +1,77 @@
+package com.fontolan.spring.securitykeyvault.example.application.service;
+
+import com.fontolan.spring.securitykeyvault.example.domain.model.UserDevice;
+import com.fontolan.spring.securitykeyvault.example.domain.repository.UserDeviceRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class UserDeviceServiceTest {
+    private UserDeviceRepository repository;
+    private NotificationService notification;
+    private UserDeviceService service;
+    private HttpServletRequest request;
+
+    @BeforeEach
+    void setup() {
+        repository = mock(UserDeviceRepository.class);
+        notification = mock(NotificationService.class);
+        service = new UserDeviceService(repository, notification);
+        request = mock(HttpServletRequest.class);
+        when(request.getHeader("User-Agent")).thenReturn("agent");
+        when(request.getRemoteAddr()).thenReturn("ip");
+    }
+
+    @Test
+    void createNewDevice() {
+        when(repository.findByUsernameAndUserAgentAndIp("u", "agent", "ip"))
+                .thenReturn(Optional.empty());
+        UserDevice saved = new UserDevice();
+        when(repository.save(any())).thenReturn(saved);
+
+        UserDevice result = service.registerOrUpdate("u", request);
+
+        assertThat(result).isSameAs(saved);
+        ArgumentCaptor<UserDevice> captor = ArgumentCaptor.forClass(UserDevice.class);
+        verify(repository).save(captor.capture());
+        UserDevice toSave = captor.getValue();
+        assertThat(toSave.getUsername()).isEqualTo("u");
+        assertThat(toSave.isTrusted()).isFalse();
+        verify(notification).sendSuspiciousLogin("u", "agent" + "ip");
+    }
+
+    @Test
+    void updateExistingDevice() {
+        UserDevice existing = new UserDevice();
+        existing.setTrusted(true);
+        when(repository.findByUsernameAndUserAgentAndIp("u", "agent", "ip"))
+                .thenReturn(Optional.of(existing));
+        when(repository.save(existing)).thenReturn(existing);
+
+        UserDevice result = service.registerOrUpdate("u", request);
+        assertThat(result).isSameAs(existing);
+        assertThat(existing.getLastUsed()).isNotNull();
+        verify(notification, never()).sendSuspiciousLogin(anyString(), anyString());
+    }
+
+    @Test
+    void listAndTrusted() {
+        List<UserDevice> list = List.of(new UserDevice());
+        when(repository.findByUsername("u")).thenReturn(list);
+        assertThat(service.listDevices("u")).isEqualTo(list);
+
+        UserDevice trusted = new UserDevice();
+        trusted.setTrusted(true);
+        when(repository.findByUsernameAndUserAgentAndIp("u", "agent", "ip"))
+                .thenReturn(Optional.of(trusted));
+        assertThat(service.isTrustedDevice("u", request)).isTrue();
+    }
+}

--- a/src/test/java/com/fontolan/spring/securitykeyvault/example/application/service/UserServiceTest.java
+++ b/src/test/java/com/fontolan/spring/securitykeyvault/example/application/service/UserServiceTest.java
@@ -1,0 +1,187 @@
+package com.fontolan.spring.securitykeyvault.example.application.service;
+
+import com.fontolan.spring.securitykeyvault.example.domain.model.Role;
+import com.fontolan.spring.securitykeyvault.example.domain.model.User;
+import com.fontolan.spring.securitykeyvault.example.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+public class UserServiceTest {
+    private UserRepository repository;
+    private PasswordEncoder encoder;
+    private NotificationService notification;
+    private TwoFactorAuthService twoFactor;
+    private UserService service;
+
+    @BeforeEach
+    void setup() {
+        repository = mock(UserRepository.class);
+        encoder = mock(PasswordEncoder.class);
+        notification = mock(NotificationService.class);
+        twoFactor = mock(TwoFactorAuthService.class);
+        service = new UserService(repository, encoder, notification, twoFactor);
+    }
+
+    @Test
+    void saveEncodesPasswordAndGeneratesSecret() {
+        User user = new User();
+        user.setUsername("u");
+        user.setPassword("p");
+        user.setRoles(Set.of(Role.ROLE_USER));
+        user.setTwoFactorEnabled(true);
+        when(encoder.encode("p")).thenReturn("enc");
+        when(twoFactor.generateSecret()).thenReturn("sec");
+
+        service.save(user);
+
+        assertThat(user.getPassword()).isEqualTo("enc");
+        assertThat(user.getTwoFactorSecret()).isEqualTo("sec");
+        verify(repository).save(user);
+    }
+
+    @Test
+    void generateResetTokenSendsEmail() {
+        User user = new User();
+        user.setUsername("u");
+        when(repository.findByUsername("u")).thenReturn(Optional.of(user));
+
+        service.generateResetToken("u");
+
+        verify(repository).save(user);
+        verify(notification).sendToken(eq("u"), anyString());
+        assertThat(user.getResetToken()).isNotNull();
+        assertThat(user.getResetTokenExpiry()).isAfter(LocalDateTime.now().minusSeconds(1));
+    }
+
+    @Test
+    void generateResetTokenUserNotFound() {
+        when(repository.findByUsername("x")).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.generateResetToken("x"))
+                .isInstanceOf(UsernameNotFoundException.class);
+    }
+
+    @Test
+    void resetPasswordFlow() {
+        User user = new User();
+        user.setResetToken("t");
+        user.setResetTokenExpiry(LocalDateTime.now().plusMinutes(1));
+        when(repository.findByResetToken("t")).thenReturn(Optional.of(user));
+        when(encoder.encode("n")).thenReturn("enc");
+
+        service.resetPassword("t", "n");
+
+        verify(repository).save(user);
+        assertThat(user.getPassword()).isEqualTo("enc");
+        assertThat(user.getResetToken()).isNull();
+    }
+
+    @Test
+    void resetPasswordInvalidToken() {
+        when(repository.findByResetToken("bad")).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.resetPassword("bad", "n"))
+                .isInstanceOf(UsernameNotFoundException.class);
+    }
+
+    @Test
+    void resetPasswordExpired() {
+        User user = new User();
+        user.setResetToken("t");
+        user.setResetTokenExpiry(LocalDateTime.now().minusMinutes(1));
+        when(repository.findByResetToken("t")).thenReturn(Optional.of(user));
+        assertThatThrownBy(() -> service.resetPassword("t", "n"))
+                .isInstanceOf(UsernameNotFoundException.class);
+    }
+
+    @Test
+    void validateLoginToken() {
+        User user = new User();
+        user.setResetToken("t");
+        user.setResetTokenExpiry(LocalDateTime.now().plusMinutes(1));
+        when(repository.findByResetToken("t")).thenReturn(Optional.of(user));
+
+        User result = service.validateLoginToken("t");
+
+        verify(repository).save(user);
+        assertThat(result).isSameAs(user);
+        assertThat(user.getResetToken()).isNull();
+    }
+
+    @Test
+    void validateLoginTokenInvalid() {
+        when(repository.findByResetToken("bad")).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.validateLoginToken("bad"))
+                .isInstanceOf(UsernameNotFoundException.class);
+    }
+
+    @Test
+    void validateLoginTokenExpired() {
+        User user = new User();
+        user.setResetToken("t");
+        user.setResetTokenExpiry(LocalDateTime.now().minusMinutes(1));
+        when(repository.findByResetToken("t")).thenReturn(Optional.of(user));
+        assertThatThrownBy(() -> service.validateLoginToken("t"))
+                .isInstanceOf(UsernameNotFoundException.class);
+    }
+
+    @Test
+    void deleteDelegates() {
+        service.delete(5L);
+        verify(repository).deleteById(5L);
+    }
+
+    @Test
+    void loadUserByUsername() {
+        User user = new User();
+        user.setUsername("u");
+        user.setPassword("p");
+        user.setRoles(Set.of(Role.ROLE_ADMIN));
+        when(repository.findByUsername("u")).thenReturn(Optional.of(user));
+
+        UserDetails details = service.loadUserByUsername("u");
+        assertThat(details.getUsername()).isEqualTo("u");
+        assertThat(details.getAuthorities()).anySatisfy(a ->
+                assertThat(a.getAuthority()).isEqualTo("ROLE_ADMIN"));
+    }
+
+    @Test
+    void loadUserByUsernameNotFound() {
+        when(repository.findByUsername("x")).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.loadUserByUsername("x"))
+                .isInstanceOf(UsernameNotFoundException.class);
+    }
+
+    @Test
+    void getByUsername() {
+        User user = new User();
+        when(repository.findByUsername("u")).thenReturn(Optional.of(user));
+        assertThat(service.getByUsername("u")).isSameAs(user);
+    }
+
+    @Test
+    void getByUsernameNotFound() {
+        when(repository.findByUsername("x")).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.getByUsername("x"))
+                .isInstanceOf(UsernameNotFoundException.class);
+    }
+
+    @Test
+    void twoFactorDelegates() {
+        when(twoFactor.generateSecret()).thenReturn("s");
+        assertThat(service.generateTwoFactorSecret()).isEqualTo("s");
+        when(twoFactor.verifyCode("s", 123456)).thenReturn(true);
+        assertThat(service.verifyTwoFactorCode("s", 123456)).isTrue();
+    }
+}

--- a/src/test/java/com/fontolan/spring/securitykeyvault/example/infrastructure/config/ConfigBeansTest.java
+++ b/src/test/java/com/fontolan/spring/securitykeyvault/example/infrastructure/config/ConfigBeansTest.java
@@ -1,0 +1,50 @@
+package com.fontolan.spring.securitykeyvault.example.infrastructure.config;
+
+import com.fontolan.spring.securitykeyvault.example.application.service.SecretsManagerService;
+import com.fontolan.spring.securitykeyvault.example.adapters.security.jwt.JwtAuthenticationFilter;
+import com.fontolan.spring.securitykeyvault.example.adapters.security.oauth2.CustomOAuth2UserService;
+import com.fontolan.spring.securitykeyvault.example.application.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+import javax.sql.DataSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class ConfigBeansTest {
+
+    @Test
+    void databaseAndPasswordBeans() {
+        AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+        ctx.registerBean(SecretsManagerService.class, SecretsManagerService::new);
+        ctx.register(DatabaseConfig.class);
+        ctx.register(PasswordConfig.class);
+        ctx.refresh();
+        assertThat(ctx.getBean(DataSource.class)).isNotNull();
+        assertThat(ctx.getBean(PasswordEncoder.class)).isNotNull();
+        ctx.close();
+    }
+
+    @Test
+    void mailAndTwoFactorBeans() {
+        AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(MailConfig.class, TwoFactorConfig.class);
+        assertThat(ctx.getBean(org.springframework.mail.javamail.JavaMailSender.class)).isNotNull();
+        assertThat(ctx.getBean(com.fontolan.spring.securitykeyvault.example.application.service.TwoFactorAuthService.class)).isNotNull();
+        ctx.close();
+    }
+
+    @Test
+    void securityConfigCreatesFilterChain() {
+        AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+        ctx.registerBean(UserService.class, () -> mock(UserService.class));
+        ctx.registerBean(JwtAuthenticationFilter.class, () -> mock(JwtAuthenticationFilter.class));
+        ctx.registerBean(CustomOAuth2UserService.class, () -> mock(CustomOAuth2UserService.class));
+        ctx.register(SecurityConfig.class);
+        ctx.refresh();
+        assertThat(ctx.getBean(SecurityFilterChain.class)).isNotNull();
+        ctx.close();
+    }
+}


### PR DESCRIPTION
## Summary
- add application context test
- add unit tests for JwtUtil and TokenService
- add extensive tests for UserService and UserDeviceService
- cover 2FA and notification logic
- verify jwt filter, controllers, and configuration beans

## Testing
- `gradle test --no-daemon --offline` *(fails: Plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531eaa204c832f96d59cbb4ea61402